### PR TITLE
シナリオ読み込み時にキャッシュしない

### DIFF
--- a/app/engine.js
+++ b/app/engine.js
@@ -45,7 +45,9 @@ class Engine {
 
   async evaluateScript(path){
     //TODO: あらゆる観点でのエラー処理, 単にfetchを呼ぶのではなくオプションを正しく指定したwrapperを用意したい（redirectをフォローすべきでない、等があるので。）
-    const response = await fetch(path);
+    const requestHead = { headers: new Headers({ 'pragma': 'no-cache', 'cache-control': 'no-cache'}) };
+    const request = new Request(path);
+    const response = await fetch(request, requestHead);
     const raw = await response.text();
     const asyncGameFunc = new Function("resolve", "tags", this.transform(raw));
     await ((tags)=>{


### PR DESCRIPTION
無邪気にPRを投げてみました！こういうゲームエンジンでは素人なので、当たり障りがないところを…。

自分で触って見たときに、`scenario/first.js`変更したときにキャッシュが効いてるせいで反映されないので、無効にして見ました。
他のevalueteXXにも入れたほうがいいのかちょっと悩んだんですが、ラッパー作ったりとか構想がありそうだったので、レビューしてもらったら方針に沿うように整えたいと思いますー。